### PR TITLE
Initialize the filesystem in the entrypoint script (Fixes #2)

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -1,38 +1,51 @@
-FROM alpine:latest
-MAINTAINER GoCD <go-cd-dev@googlegroups.com>
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-ARG GO_WORKING_DIR="/go-working-dir"
-ARG VOLUME_DIR="/godata"
+FROM alpine:latest
+
+MAINTAINER GoCD <go-cd-dev@googlegroups.com>
 
 ARG GOCD_VERSION="<%= gocd_version %>"
 ARG DOWNLOAD_URL="<%= download_url %>"
+ARG GID=1000
+ARG UID=1000
 
 ADD ${DOWNLOAD_URL} /tmp/go-server.zip
 
-RUN apk add --update-cache openjdk8-jre-base git mercurial subversion tini openssh-client bash && \
-# unzip the zip file into /go-server, after stripping the first path prefix
-  unzip /tmp/go-server.zip -d / && \
-  mv go-server-${GOCD_VERSION} /go-server && \
-# Exposing volumes in a simple manner, and setup links behind-the-scenes
-# to match GoCD's directory structure
-  mkdir -p ${GO_WORKING_DIR} && \
-<% %w(artifacts config db logs plugins addons).each do |dir| -%>
-  mkdir -p ${VOLUME_DIR}/<%= dir %> && \
-  ln -sf ${VOLUME_DIR}/<%= dir %> ${GO_WORKING_DIR}/<%= dir %> && \
-<% end -%>
-  adduser -D go && \
-  chown -R go:go ${VOLUME_DIR} ${GO_WORKING_DIR}
 
 # allow mounting ssh keys, dotfiles, and the go server config and data
-VOLUME ["/home/go", "${VOLUME_DIR}"]
+VOLUME /home/go /godata
 
 # the ports that go server runs on
 EXPOSE 8153 8154
 
-USER go
-ENTRYPOINT ["/sbin/tini", "--"]
-WORKDIR ${GO_WORKING_DIR}
-ENV GO_CONFIG_DIR=${GO_WORKING_DIR}/config
-ENV SERVER_WORK_DIR=${GO_WORKING_DIR}
-ENV STDOUT_LOG_FILE=${GO_WORKING_DIR}/logs/go-server.out.log
-CMD ["/go-server/server.sh"]
+# force encoding
+ENV LANG=en_US.utf8
+
+RUN \
+# add our user and group first to make sure their IDs get assigned consistently,
+# regardless of whatever dependencies get added
+  addgroup -g ${GID} -S go && \
+  adduser -D -u ${UID} -G go go && \
+# install dependencies and other helpful CLI tools
+  apk --update-cache upgrade && \
+  apk add --update-cache openjdk8-jre-base git mercurial subversion tini openssh-client bash su-exec && \
+# unzip the zip file into /go-server, after stripping the first path prefix
+  unzip /tmp/go-server.zip -d / && \
+  rm /tmp/go-server.zip && \
+  mv go-server-${GOCD_VERSION} /go-server
+
+ADD docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ task :create_dockerfile do
 end
 
 task :build_docker_image do
-  sh('docker build . -t gocd-server')
+  sh("docker build . -t gocd-server:v#{gocd_version}")
 end
 
 task :commit_dockerfile do

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+yell() { echo "$0: $*" >&2; }
+die() { yell "$*"; exit 111; }
+try() { echo "$ $@" 1>&2; "$@" || die "cannot $*"; }
+
+VOLUME_DIR="/godata"
+
+# these 3 vars are used by `/go-server/server.sh`, so we export
+export SERVER_WORK_DIR="/go-working-dir"
+export GO_CONFIG_DIR="/go-working-dir/config"
+export STDOUT_LOG_FILE="/go-working-dir/logs/go-server.out.log"
+
+# no arguments are passed so assume user wants to run the gocd server
+# we prepend "/go-server/server.sh" to the argument list
+if [[ $# -eq 0 ]] ; then
+	set -- /go-server/server.sh "$@"
+fi
+
+# if running go server as root, then initialize directory structure and call ourselves as `go` user
+if [ "$1" = '/go-server/server.sh' ]; then
+
+  if [ "$(id -u)" = '0' ]; then
+    server_dirs=(artifacts config db logs plugins addons)
+
+    yell "Creating directories and symlinks to hold GoCD configuration, data, and logs"
+
+    # ensure working dir exist
+    if [ ! -e "${SERVER_WORK_DIR}" ]; then
+      try mkdir "${SERVER_WORK_DIR}"
+      try chown go:go "${SERVER_WORK_DIR}"
+    fi
+
+    # ensure proper directory structure in the volume directory
+    if [ ! -e "${VOLUME_DIR}" ]; then
+      try mkdir "${VOLUME_DIR}"
+      try chown go:go "${SERVER_WORK_DIR}"
+    fi
+
+    for each_dir in "${server_dirs[@]}"; do
+      if [ ! -e "${VOLUME_DIR}/${each_dir}" ]; then
+        try mkdir -v "${VOLUME_DIR}/${each_dir}"
+        try chown go:go "${VOLUME_DIR}/${each_dir}"
+      fi
+
+      if [ ! -e "${SERVER_WORK_DIR}/${each_dir}" ]; then
+        try ln -sv "${VOLUME_DIR}/${each_dir}" "${SERVER_WORK_DIR}/${each_dir}"
+        try chown go:go "${SERVER_WORK_DIR}/${each_dir}"
+      fi
+    done
+
+	  try exec /sbin/tini -- su-exec go "$0" "$@" >> ${STDOUT_LOG_FILE} 2>&1
+  fi
+fi
+
+try exec "$@"


### PR DESCRIPTION
Initialization of the filesystem in the `Dockerfile` did not work
as expected with volume mounts becaue they would almost always be owned
by incompatible UID/GID thereby causing exceptions when writing to those
dirs.