### PR TITLE
can't login with go user unless explicit configuring a shell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN \
 # add our user and group first to make sure their IDs get assigned consistently,
 # regardless of whatever dependencies get added
   addgroup -g ${GID} go && \
-  adduser -D -u ${UID} -G go go && \
+  adduser -D -u ${UID} -G go -s /bin/sh go && \
 # install dependencies and other helpful CLI tools
   apk --update-cache upgrade && \
   apk add --update-cache openjdk8-jre-base git mercurial subversion tini openssh-client bash su-exec && \


### PR DESCRIPTION
To reproduce the issue:
```
docker run --rm -it -d gocd/gocd-server:v17.3.0
docker exec -it <CONTAINER_ID> /bin/sh
```
Once on the container:
```
/ # su - go
su: can't execute ',,,:/home/': No such file or directory
```
Seems something is wrong with adduser command on Alpine Linux.
```
# /etc/passwd go user entry with current master code
go:x:1000:1000:Linux User,,,:/home/go:,,,:/home/
# /etc/passwd go user entry from PR code
go:x:1000:1000:Linux User,,,:/home/go:/bin/sh
```