### PR TITLE
Add instructions about file ownerships with volume mounts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ The GoCD server will store all configuration, pipeline history database, artifac
 docker run -v /path/to/godata:/godata -v /path/to/home-dir:/home/go gocd/gocd-server
 ```
 
+> **Note:** Ensure that `/path/to/home-dir` and `/path/to/godata` is accessible by the `go` user in container (`go` user - uid 1000).
+
+## Installing plugins
+
+All plugins can be installed under `/godata`.
+
+```
+mkdir -p /path/to/godata/plugins/external
+curl --location --fail https://example.com/plugin.jar > /path/to/godata/plugins/external/plugin.jar
+chown -R 1000 /path/to/godata/plugins
+```
+
 ## Tweaking JVM options (memory, heap etc)
 
 JVM options can be tweaked using the environment variable `GO_SERVER_SYSTEM_PROPERTIES`.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ curl --location --fail https://example.com/plugin.jar > /path/to/godata/plugins/
 chown -R 1000 /path/to/godata/plugins
 ```
 
+## Installing addons
+
+All addons can be installed under `/godata`.
+
+```
+mkdir -p /path/to/godata/addons
+curl --location --fail https://example.com/addon.jar > /path/to/godata/addons/plugin.jar
+chown -R 1000 /path/to/godata/addons
+```
+
 ## Tweaking JVM options (memory, heap etc)
 
 JVM options can be tweaked using the environment variable `GO_SERVER_SYSTEM_PROPERTIES`.


### PR DESCRIPTION
* The bootstrap script will only set ownership on top level dirs in `/godata`
* Add instructions about installing plugins