### PR TITLE
Log everything to stdout as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Docker GoCD Server 17.9.0
+
+* log server output and logs to `STDOUT` in addition to writing logs to log files, so you can now watch all server logs using `docker logs`.
+
 # Docker GoCD Server 17.8.0
 
 * [e4fcb35](https://github.com/gocd/docker-gocd-server/commit/e4fcb355848877689fdf4d193d554573056c85f0) Reduce the docker GoCD server image's size by removing the downloaded binary after its extracted.

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -44,7 +44,15 @@ RUN \
 # unzip the zip file into /go-server, after stripping the first path prefix
   unzip /tmp/go-server.zip -d / && \
   rm /tmp/go-server.zip && \
-  mv go-server-<%= gocd_version %> /go-server
+  mv go-server-<%= gocd_version %> /go-server && \
+# ensure that logs are printed to console output
+  sed -i -e 's/\(log4j.rootLogger.*\)/\1, stdout/g' /go-server/config/log4j.properties && \
+  echo "" >> /go-server/config/log4j.properties && \
+  echo "" >> /go-server/config/log4j.properties && \
+  echo "# Log to stdout" >> /go-server/config/log4j.properties && \
+  echo "log4j.appender.stdout=org.apache.log4j.ConsoleAppender" >> /go-server/config/log4j.properties && \
+  echo "log4j.appender.stdout.layout=org.apache.log4j.PatternLayout" >> /go-server/config/log4j.properties && \
+  echo "log4j.appender.stdout.layout.conversionPattern=%d{ISO8601} %5p [%t] %c{1}:%L - %m%n" >> /go-server/config/log4j.properties
 
 ADD docker-entrypoint.sh /
 


### PR DESCRIPTION
* rootLogger sends log events to console appender that logs to stdout
* do not redirect the output of `server.sh` to a file