### PR TITLE
Allow arbitrary go uid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,11 +31,14 @@ EXPOSE 8153 8154
 # force encoding
 ENV LANG=en_US.utf8
 
+# allow alternative go uid
+ENV UID=1000
+
 RUN \
 # add our user and group first to make sure their IDs get assigned consistently,
 # regardless of whatever dependencies get added
-  addgroup -g 1000 go && \
-  adduser -D -u 1000 -G go go && \
+  addgroup -g ${UID} go && \
+  adduser -D -u ${UID} -G go go && \
 # install dependencies and other helpful CLI tools
   apk --no-cache upgrade && \
   apk add --no-cache openjdk8-jre-base git mercurial subversion tini openssh-client bash su-exec curl && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ EXPOSE 8153 8154
 ENV LANG=en_US.utf8
 
 # allow alternative go uid
-ENV UID=1000
+ARG UID=1000
 
 RUN \
 # add our user and group first to make sure their IDs get assigned consistently,

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -31,11 +31,14 @@ EXPOSE 8153 8154
 # force encoding
 ENV LANG=en_US.utf8
 
+# allow alternative go uid
+ENV UID=1000
+
 RUN \
 # add our user and group first to make sure their IDs get assigned consistently,
 # regardless of whatever dependencies get added
-  addgroup -g 1000 go && \
-  adduser -D -u 1000 -G go go && \
+  addgroup -g ${UID} go && \
+  adduser -D -u ${UID} -G go go && \
 # install dependencies and other helpful CLI tools
   apk --no-cache upgrade && \
   apk add --no-cache openjdk8-jre-base git mercurial subversion tini openssh-client bash su-exec curl && \

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -32,7 +32,7 @@ EXPOSE 8153 8154
 ENV LANG=en_US.utf8
 
 # allow alternative go uid
-ENV UID=1000
+ARG UID=1000
 
 RUN \
 # add our user and group first to make sure their IDs get assigned consistently,


### PR DESCRIPTION
I've been using this docker image to run acceptance tests on my terraform library, but am having trouble in travis without using sudo. Because I can not control the go user's ID, cleaning up the workspace to build a deploy artefact hits permission errors. This PR allows an arbitrary uid for the go user.

See: https://travis-ci.org/drewsonne/terraform-provider-gocd/builds/265555269#L922