### PR TITLE
Remove volume instructions

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -22,9 +22,6 @@ LABEL gocd.version="<%= gocd_version %>" \
   gocd.full.version="<%= gocd_full_version %>" \
   gocd.git.sha="<%= gocd_git_sha %>"
 
-# allow mounting the go server config and data
-VOLUME /godata
-
 # the ports that go server runs on
 EXPOSE 8153 8154
 


### PR DESCRIPTION
- Closes #25.
- Does not prevent users from specifying a volume mount in docker run.