### PR TITLE
Allow users to overwrite the environment variables

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -31,9 +31,9 @@ fi
 if [ "$1" = '/go-server/server.sh' ]; then
 
   if [ "$(id -u)" = '0' ]; then
-    export SERVER_WORK_DIR="/go-working-dir"
-    export GO_CONFIG_DIR="/go-working-dir/config"
-    export STDOUT_LOG_FILE="/go-working-dir/logs/go-server.out.log"
+    [ -z "${SERVER_WORK_DIR}" ] && export SERVER_WORK_DIR="/go-working-dir"
+    [ -z "${GO_CONFIG_DIR}" ] && export GO_CONFIG_DIR="/go-working-dir/config"
+    [ -z "${STDOUT_LOG_FILE}" ] && export STDOUT_LOG_FILE="/go-working-dir/logs/go-server.out.log"
 
     server_dirs=(artifacts config db logs plugins addons)
 


### PR DESCRIPTION
Hi,

Sometimes you want to be able to be able to overwrite the working directory and the log directory to be on different paths (for example when your working directory is on an external volume and you don't want your logs there.
This would allow us to avoid having a custom entrypoint just for that.

Thanks for your help,
Joseph