### PR TITLE
Installing nss package as it is used by jre

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -38,7 +38,7 @@ RUN \
   adduser -D -u ${UID} -s /bin/bash -G go go && \
 # install dependencies and other helpful CLI tools
   apk --no-cache upgrade && \
-  apk add --no-cache openjdk8-jre-base git mercurial subversion tini openssh-client bash su-exec curl && \
+  apk add --no-cache nss openjdk8-jre-base git mercurial subversion tini openssh-client bash su-exec curl && \
 # download the zip file
   curl --fail --location --silent --show-error "<%= download_url %>" > /tmp/go-server.zip && \
 # unzip the zip file into /go-server, after stripping the first path prefix

--- a/README.md.erb
+++ b/README.md.erb
@@ -19,7 +19,7 @@ Build one with version `<%= gocd_version %>`; zip file is from GoCD [`download`]
 
 ```shell
 GOCD_VERSION=<%= gocd_version %> \
-GOCD_FULL_VERSION=<%= gocd_full_version %>
+GOCD_FULL_VERSION=<%= gocd_full_version %> \
 GOCD_SERVER_DOWNLOAD_URL=https://download.gocd.org/binaries/<%= gocd_full_version %>/generic/go-server-<%= gocd_full_version %>.zip \
 rake build_image
 ```
@@ -30,7 +30,7 @@ By default, the UID and GID of the `go` user in the docker container is `1000`. 
 
 ```shell
 GOCD_VERSION=<%= gocd_version %> \
-GOCD_FULL_VERSION=<%= gocd_full_version %>
+GOCD_FULL_VERSION=<%= gocd_full_version %> \
 GOCD_SERVER_DOWNLOAD_URL=https://download.gocd.org/binaries/<%= gocd_full_version %>/generic/go-server-<%= gocd_full_version %>.zip \
 rake create_dockerfile
 docker build --build-arg UID=2000 --build-arg GID=2000 -t gocd-server-image:tag .


### PR DESCRIPTION
- This is done as jre has removed the package dependency from nss but is
  still uses it.