### PR TITLE
fixed subversion SASL auth error when subversion material use the svn protocol

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN \
   addgroup -g ${GID} go && \
   adduser -D -u ${UID} -s /bin/bash -G go go && \
   apk --no-cache upgrade && \
-  apk add --no-cache nss git mercurial subversion openssh-client bash curl && \
+  apk add --no-cache nss git mercurial subversion openssh-client bash curl cyrus-sasl cyrus-sasl-plain && \
   apk add --no-cache openjdk8-jre-base && \
   mkdir -p /docker-entrypoint.d
 


### PR DESCRIPTION
when subversion material use the svn protocol, we got the error 

> "svn: E210007: Cannot negotiate authentication mechanism"

both **CHECK CONNECTION** on PIPLINE Material UI and pod command use `"svn checkout"`.

![image](https://user-images.githubusercontent.com/2178025/61290507-9aabe880-a7fe-11e9-9c4d-e3a2b03e6991.png)


add the `cyrus-sasl` `cyrus-sasl-plain` packages to apk installation in Dockerfile and fix it.